### PR TITLE
Fix ingress path type

### DIFF
--- a/charts/camunda-bpm-platform/templates/ingress.yaml
+++ b/charts/camunda-bpm-platform/templates/ingress.yaml
@@ -35,7 +35,7 @@ spec:
           {{- range .paths }}
             {{- if kindIs "string" . }}
             - path: {{ . }}
-              pathType: Prefix
+              pathType: ImplementationSpecific
               backend:
                 service:
                   name: {{ $fullName }}
@@ -72,4 +72,4 @@ spec:
         {{- end -}}
     {{- end }}
   {{- end }}
-  
+


### PR DESCRIPTION
From the official docs: https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/1772

Add support for Ingress pathType introduced in K8s 1.18+: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types

```
The pathType will default to be ImplementationSpecific if unspecified.
For ImplementationSpecific PathType:
path can contain wildcards: "*" or "?"
the generated path pattern will be same as path specified in IngressSpec
For Exact PathType:
path shouldn't contains any wildcards: "*" or "?"
the generated path pattern will be same as path specified in IngressSpec.
For Prefix PathType:
path shouldn't contains any wildcards: "*" or "?"
for /, the generated path pattern will be "/*"
for /abc/def, the generated path pattern will be "/abc/def" and "/abc/def/*"
```